### PR TITLE
Link retry

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def already_taken?(field)
+    errors.details[field].any? { |detail| detail[:error] == :taken }
+  end
 end


### PR DESCRIPTION
## Summary

- Retry link generation if there is a collision in the `code` field

### Comments

- This is not ideal if the platform scales up, since we're adding extra queries and nothing guarantees it won't collide the second time.
Ideas for making this better in terms of high scalability could be implementing a "garbage collector" of links that were never used or haven't been used in a long time (to be defined), and/or implementing a distributed and synchronised counter instead of a random number generator